### PR TITLE
`stack exec CMD` requires `--` before arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ stack build
 Finally you can run the compiler on a simple example:
 
 ```
-$ stack exec Ling --seq --fuse --pretty --compile fixtures/compile/double.ll
+$ stack exec Ling -- --seq --fuse --pretty --compile fixtures/compile/double.ll
 ```
 
 The command above is type checking, apply sequencing and fusion. It finally


### PR DESCRIPTION
Hi, this is a great project!

Executing current example command resulted in:

```
$ stack exec Ling --seq --fuse --pretty --compile fixtures/compile/double.ll
Invalid option `--seq'

Usage: stack exec CMD [-- ARGS (e.g. stack ghc -- X.hs -o x)] ([--plain] |
                  [--[no-]ghc-package-path] [--[no-]stack-exe] [--package ARG])
                  [--help]
  Execute a command
```

And this worked:

```
$ stack exec Ling -- --seq --fuse --pretty --compile fixtures/compile/double.ll
Checking Sucessful!

...
```

Hence the Pull Request.

Thanks,
Oleksii
